### PR TITLE
Global module config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Add the ngxVibration directive to an HTML element. The directive takes a vibrati
 ```html
 <button [ngxVibration]="[200, 100, 200]">VIBRATE</button>
 ```
+```html
+<button [ngxVibration]="500">VIBRATE</button>
+```
+Or with the [global config](#global-configuration) _defaultPattern_ set: 
+```html
+<button ngxVibration>VIBRATE</button>
+```
 
 ### Vibration Service
 
@@ -49,3 +56,18 @@ export class AppComponent implements OnInit {
   }
 }
 ```
+
+### Global configuration
+
+You can provide a default configuration object when importing the module using the `forRoot()` method.
+
+``` typescript
+NgxVibrationModule.forRoot({
+  defaultPattern: [100, 0, 100]
+})
+```
+
+| Property       | Type       | Description                                                  |
+| -------------- | ---------- | ------------------------------------------------------------ |
+| defaultPattern | `number[]` | The pattern to use by default when no other is specified on the directives |
+

--- a/projects/ngx-vibration/README.md
+++ b/projects/ngx-vibration/README.md
@@ -27,6 +27,13 @@ Add the ngxVibration directive to an HTML element. The directive takes a vibrati
 ```html
 <button [ngxVibration]="[200, 100, 200]">VIBRATE</button>
 ```
+```html
+<button [ngxVibration]="500">VIBRATE</button>
+```
+Or with the [global config](#global-configuration) _defaultPattern_ set: 
+```html
+<button ngxVibration>VIBRATE</button>
+```
 
 ### Vibration Service
 
@@ -49,3 +56,18 @@ export class AppComponent implements OnInit {
   }
 }
 ```
+
+### Global configuration
+
+You can provide a default configuration object when importing the module using the `forRoot()` method.
+
+``` typescript
+NgxVibrationModule.forRoot({
+  defaultPattern: [100, 0, 100]
+})
+```
+
+| Property       | Type       | Description                                                  |
+| -------------- | ---------- | ------------------------------------------------------------ |
+| defaultPattern | `number[]` | The pattern to use by default when no other is specified on the directives |
+

--- a/projects/ngx-vibration/src/lib/ngx-vibration.config.ts
+++ b/projects/ngx-vibration/src/lib/ngx-vibration.config.ts
@@ -1,0 +1,9 @@
+import { InjectionToken } from '@angular/core';
+
+export interface NgxVibrationConfig {
+    defaultPattern?: number[];
+}
+
+export const GLOBAL_CONFIG_TOKEN = new InjectionToken<NgxVibrationConfig>(
+    'GLOBAL_CONFIG'
+);

--- a/projects/ngx-vibration/src/lib/ngx-vibration.module.ts
+++ b/projects/ngx-vibration/src/lib/ngx-vibration.module.ts
@@ -1,9 +1,18 @@
-import { NgModule } from "@angular/core";
-import { VibrationDirective } from "./vibration.directive";
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { VibrationDirective } from './vibration.directive';
+import { GLOBAL_CONFIG_TOKEN, NgxVibrationConfig } from './ngx-vibration.config';
 
 @NgModule({
   declarations: [VibrationDirective],
   imports: [],
   exports: [VibrationDirective],
 })
-export class NgxVibrationModule {}
+export class NgxVibrationModule {
+  static forRoot(config: NgxVibrationConfig): ModuleWithProviders<NgxVibrationModule> {
+    return {
+      ngModule: NgxVibrationModule,
+      providers: [{ provide: GLOBAL_CONFIG_TOKEN, useValue: config }],
+    };
+  }
+}
+

--- a/projects/ngx-vibration/src/lib/ngx-vibration.service.ts
+++ b/projects/ngx-vibration/src/lib/ngx-vibration.service.ts
@@ -1,9 +1,13 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { GLOBAL_CONFIG_TOKEN, NgxVibrationConfig } from './ngx-vibration.config';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NgxVibrationService {
+  constructor(@Optional() @Inject(GLOBAL_CONFIG_TOKEN)
+              public readonly config: NgxVibrationConfig | null) {
+  }
 
   /**
    * Takes vibrationPattern as input and returns a boolean indicating success

--- a/projects/ngx-vibration/src/lib/vibration.directive.ts
+++ b/projects/ngx-vibration/src/lib/vibration.directive.ts
@@ -1,12 +1,41 @@
-import { Directive, Input, HostListener } from "@angular/core";
-import { NgxVibrationService } from "./ngx-vibration.service";
+import { Directive, HostListener, Input } from '@angular/core';
+import { NgxVibrationService } from './ngx-vibration.service';
 
 @Directive({
   selector: "[ngxVibration]",
 })
 export class VibrationDirective {
-  @Input("ngxVibration")
-  vibratePattern: number[];
+  private vibratePattern: number[];
+
+  /**
+   * Handle directive arguments
+   * Accepts pattern or digits as string or number
+   */
+  @Input('ngxVibration')
+  set inputPattern(input: number[] | number | string) {
+    if (typeof input === 'string') {
+      if (input) {
+        if (!input.match(/^\d+$/)) {
+          // The input does not match a number
+          throw new Error('At least one number is expected as vibration pattern');
+        }
+        // Building the pattern from the given number
+        this.vibratePattern = [parseInt(input, 10)];
+      } else {
+        // No input was given, falling back to module config
+        const defaultPattern = this.vibrationService.config?.defaultPattern;
+        if (!defaultPattern) {
+          throw new Error('No pattern provided in vibrate() call nor module configuration');
+        }
+        this.vibratePattern = defaultPattern;
+      }
+    } else if (typeof input === 'number') {
+      // Building the pattern from the given number
+      this.vibratePattern = [input];
+    } else {
+      this.vibratePattern = input;
+    }
+  }
 
   constructor(private vibrationService: NgxVibrationService) {}
 


### PR DESCRIPTION
Introduces a global configuration object for the module.
For now it accepts a default pattern to use across all directive instances. This allows to use `ngxVibration` as is with no other arguments.
Also, accepting single number arguments for the directive, including as strings, feels more convenient.